### PR TITLE
feat: custom hook usePosition to consume geolocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ package-lock.json
 # production
 /build
 /dist
+dev-dist/
 
 # misc
 .bak
@@ -14,3 +15,4 @@ package-lock.json
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode

--- a/client/src/hooks/usePosition.tsx
+++ b/client/src/hooks/usePosition.tsx
@@ -31,7 +31,12 @@ export const usePosition = () => {
 
   useEffect(() => {
     if ("geolocation" in navigator) {
-      navigator.geolocation.watchPosition(handleSuccess, handleError);
+      const options = {
+        enableHighAccuracy: true,
+        maximumAge: 30000,
+        timeout: 60000
+      }
+      navigator.geolocation.watchPosition(handleSuccess, handleError, options);
     } else {
       setError("Navigator doesn't support geolocation");
     }

--- a/client/src/hooks/usePosition.tsx
+++ b/client/src/hooks/usePosition.tsx
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+
+interface Position {
+  timestamp?: string;
+  latitude?: number;
+  longitude?: number;
+  accuracy?: number;
+  heading?: number;
+  speed?: number;
+  error?: string;
+}
+
+export const usePosition = () => {
+  const [position, setPosition] = useState({});
+  const [error, setError] = useState("");
+
+  function handleSuccess (position: GeolocationPosition) {
+    setPosition({
+      timestamp: position.timestamp,
+      latitude: position.coords.latitude,
+      longitude: position.coords.longitude,
+      accuracy: position.coords.accuracy,
+      heading: position.coords.heading,
+      speed: position.coords.speed
+    });
+  }
+
+  function handleError (error: GeolocationPositionError) {
+    setError(error.message);
+  }
+
+  useEffect(() => {
+    if ("geolocation" in navigator) {
+      navigator.geolocation.watchPosition(handleSuccess, handleError);
+    } else {
+      setError("Navigator doesn't support geolocation");
+    }
+  }, [])
+  return {...position, error} as Position;
+}


### PR DESCRIPTION
This custom hook gives access to the geolocation.
Import in the component:
`import { usePosition } from "./hooks/usePosition"`
And then use like this:
`const { timestamp, latitude, longitude, accuracy, heading, speed, error } = usePosition();`
Of course, you can only destructure the parts you need.