### PR TITLE
fix: authMiddleware variable renamed + put returns on new line

### DIFF
--- a/server/middleware/authMiddleware.ts
+++ b/server/middleware/authMiddleware.ts
@@ -1,5 +1,5 @@
 import jwt from "jsonwebtoken";
-import { Request, Response, NextFunction, } from "express";
+import { Request, Response, NextFunction } from "express";
 import UserModel from "../models/user";
 import dotenv from 'dotenv';
 import { UserI } from "../Types/user";
@@ -12,15 +12,21 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
     // REMOVE-START
     // extract token from auth headers
     const authHeaders = req.headers['authorization'];
-    if (!authHeaders) return res.sendStatus(403);
+    if (!authHeaders) {
+        res.sendStatus(403);
+        return;
+    }
     const token = authHeaders.split(' ')[1];
 
     try {
         // verify & decode token payload,
-        const { _id } = jwt.verify(token, SECRET_KEY) as UserI;
+        const { id } = jwt.verify(token, SECRET_KEY) as UserI;
         // attempt to find user object and set to req
-        const user = await UserModel.findOne({ _id });
-        if (!user) return res.sendStatus(401);
+        const user = await UserModel.findOne({ _id: id });
+        if (!user) {
+            res.sendStatus(401);
+            return;
+        }
         req.user = user;
         next();
     } catch (error) {


### PR DESCRIPTION
Hi Melissa, I renamed a variable in the authMiddleware to make it work. Also I had to put all returns in a new line so they wouldn't actually return the res object. Typescript was not happy about that once I tried to plug the middleware into my route. Please review and accept if you agree with the changes. Thanks!